### PR TITLE
Enable collecting memory percentages and lower TTL for all metrics

### DIFF
--- a/jobs/collectd/spec
+++ b/jobs/collectd/spec
@@ -10,6 +10,7 @@ templates:
   collectd.d/df.conf: collectd.d/df.conf
   collectd.d/cpu.conf: collectd.d/cpu.conf
   collectd.d/swap.conf: collectd.d/swap.conf
+  collectd.d/memory.conf: collectd.d/memory.conf
   collectd.d/config.conf.erb: collectd.d/config.conf
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh

--- a/jobs/collectd/templates/collectd.d/memory.conf
+++ b/jobs/collectd/templates/collectd.d/memory.conf
@@ -1,0 +1,4 @@
+LoadPlugin "memory"
+<Plugin memory>
+  ValuesPercentage true
+</Plugin>

--- a/jobs/collectd/templates/collectd.d/write_riemann.conf.erb
+++ b/jobs/collectd/templates/collectd.d/write_riemann.conf.erb
@@ -6,7 +6,7 @@ LoadPlugin "write_riemann"
     Protocol TCP
     CheckThresholds true
     StoreRates false
-    TTLFactor 30.0
+    TTLFactor 5.0
   </Node>
   Tag "collectd"
 </Plugin>


### PR DESCRIPTION
Required so we can alert when logstash redis queue is approaching full https://github.com/18F/cg-atlas/issues/196
